### PR TITLE
Add mobile_notice back for iOS alert

### DIFF
--- a/prod/wallet-options.json
+++ b/prod/wallet-options.json
@@ -250,6 +250,9 @@
   "ios": {
     "showShapeshift": false
   },
+  "mobile_notice": {
+    "en": "The Bitcoin and Ethereum networks are currently experiencing record high traffic, resulting in higher miner's fees and longer confirmation times for transactions."
+  },
   "mobileInfo": {
     "en": "The Bitcoin and Ethereum networks are currently experiencing record high traffic, resulting in higher miner's fees and longer confirmation times for transactions."
   },


### PR DESCRIPTION
We just need to make sure this doesn’t create any duplicate messaging on Android