### PR TITLE
Turn off recurring buy

### DIFF
--- a/prod/wallet-options.json
+++ b/prod/wallet-options.json
@@ -121,7 +121,7 @@
         "https://blockchain.co1.qualtrics.com/jfe/form/SV_9ysiGRC4rkMFwFv"
       ],
       "showSellFraction": 1,
-      "showRecurringBuy": true
+      "showRecurringBuy": false
     },
     "sfox": {
       "disabled": false,


### PR DESCRIPTION
Coinify has already turned this off on their end, just hiding it in the UI. Won't require a build, and I've double checked that this works as expected. Can deploy to prod whenever. Thanks