### PR TITLE
Remove XLM issue notice on android.

### DIFF
--- a/prod/wallet-options.json
+++ b/prod/wallet-options.json
@@ -275,9 +275,6 @@
     "showShapeshift": true,
     "showSfox": false
   },
-  "mobileInfo": {
-    "en": "The technical issue affecting Stellar XLM functionality has been fixed. Please update the app to see the fix reflected."
-  },
   "ios": {
     "showShapeshift": true,
     "showSfox": false


### PR DESCRIPTION
We have > 80% adoption of version 6.24.1 and above now so we can remove this notice now.