### PR TITLE
feat(ForceUpdate): IOS-2166 - add update construct

### DIFF
--- a/dev/wallet-options.json
+++ b/dev/wallet-options.json
@@ -264,6 +264,10 @@
     "showSfox": true
   },
   "ios": {
+    "update": {
+      "updateType": "none",
+      "latestStoreVersion": ""
+    },
     "showShapeshift": true,
     "showSfox": true
   },

--- a/prod/wallet-options.json
+++ b/prod/wallet-options.json
@@ -315,6 +315,10 @@
     "showSfox": false
   },
   "ios": {
+    "update": {
+      "updateType": "none",
+      "latestStoreVersion": ""
+    },
     "showShapeshift": true,
     "showSfox": false
   },

--- a/src/schema.js
+++ b/src/schema.js
@@ -123,6 +123,10 @@ const v3 = object({
     showSfox: bool()
   }),
   ios: object({
+    update: object({
+      updateType: string(),
+      latestStoreVersion: string()
+    }),
     showShapeshift: bool(),
     showSfox: bool()
   }),

--- a/staging/wallet-options.json
+++ b/staging/wallet-options.json
@@ -272,6 +272,10 @@
     "showSfox": false
   },
   "ios": {
+    "update": {
+      "updateType": "none",
+      "latestStoreVersion": ""
+    },
     "showShapeshift": true,
     "showSfox": false
   },

--- a/testnet/wallet-options.json
+++ b/testnet/wallet-options.json
@@ -199,6 +199,10 @@
     "walletRoot": "https://testnet.blockchain.info/wallet"
   },
   "ios": {
+    "update": {
+      "updateType": "none",
+      "latestStoreVersion": ""
+    },
     "showShapeshift": false,
     "showSfox": true
   },


### PR DESCRIPTION
To support the app update prompt, I added to dev, prod, staging, testnet necessary construct, under `ios`. See below:
```json
    "update": {
      "updateType": "none",
      "latestStoreVersion": ""
    }
```
Old iOS wallets will disregard that change.

Possible updateType values are: "forced", "recommended", "none". any other value will be considered as "none".
Possible latestStoreVersion values: any valid version with x.y.z format.

*schema validation run successfully*