### PR TITLE
Feat(Send and request service announcements)

### DIFF
--- a/dev/wallet-options-v4.json
+++ b/dev/wallet-options-v4.json
@@ -28,6 +28,8 @@
             }
           },
           "public": {},
+          "request": {},
+          "send": {},
           "swap": {},
           "wallet": {}
         }

--- a/prod/wallet-options-v4.json
+++ b/prod/wallet-options-v4.json
@@ -28,6 +28,8 @@
             }
           },
           "public": {},
+          "request": {},
+          "send": {},
           "swap": {},
           "wallet": {}
         }

--- a/src/data.js
+++ b/src/data.js
@@ -25,7 +25,6 @@ exports.countries = [
   'UG', 'UA', 'AE', 'GB', 'US', 'UM', 'UY', 'UZ', 'VU', 'VE',
   'VN', 'VI', 'WF', 'EH', 'YE', 'ZM', 'ZW'
 ]
-
 exports.states = [
   'AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA',
   'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD',
@@ -33,3 +32,4 @@ exports.states = [
   'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC',
   'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY'
 ]
+exports.supportedCoins = ['BTC', 'BCH', 'ETH', 'PAX', 'XLM']

--- a/src/schema.js
+++ b/src/schema.js
@@ -146,6 +146,8 @@ const v4 = object({
         announcements: optional(object({
           lockbox: optional(webServiceAlert()),
           public: optional(webServiceAlert()),
+          request: optional(webServiceAlert()),
+          send: optional(webServiceAlert()),
           swap: optional(webServiceAlert()),
           wallet: optional(webServiceAlert())
         }))

--- a/src/types.js
+++ b/src/types.js
@@ -1,49 +1,36 @@
-const { countries, states } = require('./data')
-
-exports.object = (properties) => ({ type: 'object', required: true, properties, additionalProperties: false })
-
-exports.string = () => ({ type: 'string', required: true })
-
-exports.number = () => ({ type: 'number', required: true })
-
-exports.bool = () => ({ type: 'boolean', required: true })
-
-exports.either = (a, b) => ({ oneOf: [a, b] })
-
-exports.nullable = (type) => exports.either(type, { type: 'null' })
-
-exports.optional = (type) => Object.assign(type, { required: false })
+const { countries, states, supportedCoins } = require('./data')
 
 exports.arrayOf = (items) => ({ type: 'array', items })
-
-exports.enumOf = (options) => ({ enum: options })
-
-exports.just = (val) => exports.enumOf([val])
-
+exports.bool = () => ({ type: 'boolean', required: true })
 exports.country = () => exports.enumOf(countries)
-
-exports.state = () => exports.enumOf(states)
-
-exports.integer = () => Object.assign(exports.number(), { divisibleBy: 1 })
-
+exports.either = (a, b) => ({ oneOf: [a, b] })
+exports.enumOf = (options) => ({ enum: options })
 exports.fraction = () => Object.assign(exports.number(), { minimum: 0, maximum: 1 })
-
+exports.integer = () => Object.assign(exports.number(), { divisibleBy: 1 })
+exports.just = (val) => exports.enumOf([val])
 exports.localizedMessage = () => ({ type: 'object', required: true, properties: { 'en': exports.string() } })
+exports.nullable = (type) => exports.either(type, { type: 'null' })
+exports.number = () => ({ type: 'number', required: true })
+exports.object = (properties) => ({ type: 'object', required: true, properties, additionalProperties: false })
+exports.optional = (type) => Object.assign(type, { required: false })
+exports.state = () => exports.enumOf(states)
+exports.string = () => ({ type: 'string', required: true })
 
 exports.webServiceAlert = () => exports.object({
-  id: exports.optional(exports.string()),
-  icon: exports.optional(exports.string()),
-  type: exports.enumOf(['info', 'warning', 'danger']),
+  action: exports.optional(exports.object({
+    title: exports.optional(exports.localizedMessage()),
+    link: exports.optional(exports.string())
+  })),
+  coins: exports.optional(exports.arrayOf(exports.enumOf(supportedCoins))),
   hideType: exports.optional(exports.enumOf(['collapse', 'dismiss'])),
   header: exports.optional(exports.localizedMessage()),
+  icon: exports.optional(exports.string()),
+  id: exports.optional(exports.string()),
   sections: exports.arrayOf(exports.object({
     title: exports.optional(exports.localizedMessage()),
     body: exports.localizedMessage()
   })),
-  action: exports.optional(exports.object({
-    title: exports.optional(exports.localizedMessage()),
-    link: exports.optional(exports.string())
-  }))
+  type: exports.enumOf(['info', 'warning', 'danger'])
 })
 
 exports.coin = () => exports.object({

--- a/src/types.js
+++ b/src/types.js
@@ -1,20 +1,36 @@
 const { countries, states, supportedCoins } = require('./data')
 
-exports.arrayOf = (items) => ({ type: 'array', items })
 exports.bool = () => ({ type: 'boolean', required: true })
+
+exports.coin = () => exports.enumOf(supportedCoins)
+
 exports.country = () => exports.enumOf(countries)
-exports.either = (a, b) => ({ oneOf: [a, b] })
-exports.enumOf = (options) => ({ enum: options })
-exports.fraction = () => Object.assign(exports.number(), { minimum: 0, maximum: 1 })
-exports.integer = () => Object.assign(exports.number(), { divisibleBy: 1 })
-exports.just = (val) => exports.enumOf([val])
-exports.localizedMessage = () => ({ type: 'object', required: true, properties: { 'en': exports.string() } })
-exports.nullable = (type) => exports.either(type, { type: 'null' })
-exports.number = () => ({ type: 'number', required: true })
+
 exports.object = (properties) => ({ type: 'object', required: true, properties, additionalProperties: false })
-exports.optional = (type) => Object.assign(type, { required: false })
-exports.state = () => exports.enumOf(states)
+
 exports.string = () => ({ type: 'string', required: true })
+
+exports.number = () => ({ type: 'number', required: true })
+
+exports.either = (a, b) => ({ oneOf: [a, b] })
+
+exports.nullable = (type) => exports.either(type, { type: 'null' })
+
+exports.optional = (type) => Object.assign(type, { required: false })
+
+exports.arrayOf = (items) => ({ type: 'array', items })
+
+exports.enumOf = (options) => ({ enum: options })
+
+exports.just = (val) => exports.enumOf([val])
+
+exports.state = () => exports.enumOf(states)
+
+exports.integer = () => Object.assign(exports.number(), { divisibleBy: 1 })
+
+exports.fraction = () => Object.assign(exports.number(), { minimum: 0, maximum: 1 })
+
+exports.localizedMessage = () => ({ type: 'object', required: true, properties: { 'en': exports.string() } })
 
 exports.webServiceAlert = () => exports.object({
   action: exports.optional(exports.object({

--- a/staging/wallet-options-v4.json
+++ b/staging/wallet-options-v4.json
@@ -28,6 +28,8 @@
             }
           },
           "public": {},
+          "request": {},
+          "send": {},
           "swap": {},
           "wallet": {}
         }

--- a/testnet/wallet-options-v4.json
+++ b/testnet/wallet-options-v4.json
@@ -23,6 +23,8 @@
             ],
             "action": {}
           },
+          "request": {},
+          "send": {},
           "swap": {},
           "wallet": {
             "id": "testnet-warning-wallet",


### PR DESCRIPTION
- Adds support for service alerts in send and request modals for Web
- Adds an optional `coin` array property to the `webServiceAlert` type. This allows us to show alerts for one or more coins if needed in Web

Related V4 [PR](https://github.com/blockchain/blockchain-wallet-v4-frontend/pull/1660) 