### PR TITLE
Recommended upgrade on staging.

### DIFF
--- a/staging/wallet-options.json
+++ b/staging/wallet-options.json
@@ -272,8 +272,8 @@
     "showSfox": false
   },
   "android_update": {
-    "updateType": "none",
-    "latestStoreVersion": ""
+    "updateType": "recommended",
+    "latestStoreVersion": "6.27.2"
   },
   "ios": {
     "update": {


### PR DESCRIPTION
We want users to upgrade to the latest version of the app 6.27.2. This change will recommend them to update (not force). I'm testing this on staging first, will PR a production change after.