### PR TITLE
Updating stellar horizon URL to our own node.

### DIFF
--- a/staging/wallet-options.json
+++ b/staging/wallet-options.json
@@ -7,7 +7,7 @@
     "webSocket": "wss://ws.staging.blockchain.info/inv",
     "api": "https://api.staging.blockchain.info",
     "walletHelperUrl": "https://wallet-helper.staging.blockchain.info",
-    "stellarHorizon": "https://horizon.stellar.org"
+    "stellarHorizon": "https://horizon.blockchain.com"
   },
   "network": "bitcoin",
   "showBuySellTab": [


### PR DESCRIPTION
Given some scheduled breaking changes in horizon 0.22.0 (see: https://github.com/stellar/go/releases/tag/horizon-v0.20.0), clients should point to our own Horizon nodes so we can control when we upgrade.

Will create another PR to make production changes first thing on Monday.