### PR TITLE
Rebrand(Add new Exchange url and flags)

### DIFF
--- a/dev/wallet-options-v4.json
+++ b/dev/wallet-options-v4.json
@@ -44,7 +44,8 @@
             "lockbox": true,
             "exchangeTo": true,
             "exchangeFrom": true,
-            "syncToPit": true
+            "syncToPit": true,
+            "syncToExchange": true
           },
           "coinCode": "BTC",
           "coinTicker": "BTC",
@@ -71,7 +72,8 @@
             "lockbox": true,
             "exchangeTo": true,
             "exchangeFrom": true,
-            "syncToPit": true
+            "syncToPit": true,
+            "syncToExchange": true
           },
           "coinCode": "BCH",
           "coinTicker": "BCH",
@@ -95,7 +97,8 @@
             "lockbox": false,
             "exchangeTo": false,
             "exchangeFrom": true,
-            "syncToPit": false
+            "syncToPit": false,
+            "syncToExchange": false
           },
           "coinCode": "BSV",
           "coinTicker": "BSV",
@@ -116,7 +119,8 @@
             "lockbox": true,
             "exchangeTo": true,
             "exchangeFrom": true,
-            "syncToPit": true
+            "syncToPit": true,
+            "syncToExchange": true
           },
           "coinCode": "ETH",
           "coinTicker": "ETH",
@@ -143,7 +147,8 @@
             "lockbox": false,
             "exchangeTo": true,
             "exchangeFrom": true,
-            "syncToPit": true
+            "syncToPit": true,
+            "syncToExchange": true
           },
           "coinCode": "PAX",
           "coinTicker": "PAX",
@@ -167,7 +172,8 @@
             "lockbox": false,
             "exchangeTo": false,
             "exchangeFrom": false,
-            "syncToPit": false
+            "syncToPit": false,
+            "syncToExchange": false
           },
           "campaign": "BLOCKSTACK",
           "coinCode": "STX",
@@ -189,7 +195,8 @@
             "lockbox": true,
             "exchangeTo": true,
             "exchangeFrom": true,
-            "syncToPit": true
+            "syncToPit": true,
+            "syncToExchange": true
           },
           "campaign": "sunriver",
           "coinCode": "XLM",
@@ -312,9 +319,6 @@
           "iSignThisDomain": "https://stage-verify.isignthis.com"
         }
       },
-      "thePit": {
-        "countries": []
-      },
       "sfox": {
         "countries": [
           "US"
@@ -379,6 +383,7 @@
     "coinifyPaymentDomain": "https://pay.sandbox.coinify.com",
     "comRoot": "https://dev.blockchain.com",
     "comWalletApp": "https://login-dev.blockchain.com",
+    "exchange": "https://exchange.dev.blockchain.info",
     "horizon": "https://horizon.blockchain.info",
     "ledger": "https://manager.api.live.ledger.com",
     "ledgerSocket": "wss://api.ledgerwallet.com",

--- a/prod/wallet-options-v4.json
+++ b/prod/wallet-options-v4.json
@@ -44,7 +44,8 @@
             "lockbox": true,
             "exchangeTo": true,
             "exchangeFrom": true,
-            "syncToPit": true
+            "syncToPit": true,
+            "syncToExchange": true
           },
           "coinCode": "BTC",
           "coinTicker": "BTC",
@@ -71,7 +72,8 @@
             "lockbox": true,
             "exchangeTo": true,
             "exchangeFrom": true,
-            "syncToPit": true
+            "syncToPit": true,
+            "syncToExchange": true
           },
           "coinCode": "BCH",
           "coinTicker": "BCH",
@@ -95,7 +97,8 @@
             "lockbox": false,
             "exchangeTo": false,
             "exchangeFrom": true,
-            "syncToPit": false
+            "syncToPit": false,
+            "syncToExchange": false
           },
           "coinCode": "BSV",
           "coinTicker": "BSV",
@@ -116,7 +119,8 @@
             "lockbox": true,
             "exchangeTo": true,
             "exchangeFrom": true,
-            "syncToPit": true
+            "syncToPit": true,
+            "syncToExchange": true
           },
           "coinCode": "ETH",
           "coinTicker": "ETH",
@@ -143,7 +147,8 @@
             "lockbox": false,
             "exchangeTo": true,
             "exchangeFrom": true,
-            "syncToPit": true
+            "syncToPit": true,
+            "syncToExchange": true
           },
           "coinCode": "PAX",
           "coinTicker": "PAX",
@@ -167,7 +172,8 @@
             "lockbox": false,
             "exchangeTo": false,
             "exchangeFrom": false,
-            "syncToPit": false
+            "syncToPit": false,
+            "syncToExchange": false
           },
           "campaign": "BLOCKSTACK",
           "coinCode": "STX",
@@ -189,7 +195,8 @@
             "lockbox": true,
             "exchangeTo": true,
             "exchangeFrom": true,
-            "syncToPit": true
+            "syncToPit": true,
+            "syncToExchange": true
           },
           "campaign": "sunriver",
           "coinCode": "XLM",
@@ -312,9 +319,6 @@
           "iSignThisDomain": "https://verify.isignthis.com"
         }
       },
-      "thePit": {
-        "countries": []
-      },
       "sfox": {
         "countries": [
           "US"
@@ -379,6 +383,7 @@
     "coinifyPaymentDomain": "https://pay.coinify.com",
     "comRoot": "https://www.blockchain.com",
     "comWalletApp": "https://login.blockchain.com",
+    "exchange": "https://exchange.blockchain.com",
     "horizon": "https://horizon.blockchain.info",
     "ledger": "https://manager.api.live.ledger.com",
     "ledgerSocket": "wss://api.ledgerwallet.com",

--- a/src/schema.js
+++ b/src/schema.js
@@ -178,9 +178,6 @@ const v4 = object({
           iSignThisDomain: string()
         })
       }),
-      thePit: object({
-        countries: either(just("*"), arrayOf(country()))
-      }),
       sfox: object({
         countries: arrayOf(country()),
         states: arrayOf(state()),
@@ -211,13 +208,14 @@ const v4 = object({
     coinifyPaymentDomain: string(),
     comRoot: string(),
     comWalletApp: string(),
+    exchange: string(),
     horizon: string(),
     ledger: string(),
     ledgerSocket: string(),
     mainProcess: string(),
     root: string(),
     securityProcess: string(),
-    thePit: optional(string()),
+    thePit: string(),
     veriff: string(),
     walletHelper: string(),
     webSocket: string()

--- a/staging/wallet-options-v4.json
+++ b/staging/wallet-options-v4.json
@@ -44,7 +44,8 @@
             "lockbox": true,
             "exchangeTo": true,
             "exchangeFrom": true,
-            "syncToPit": true
+            "syncToPit": true,
+            "syncToExchange": true
           },
           "coinCode": "BTC",
           "coinTicker": "BTC",
@@ -71,7 +72,8 @@
             "lockbox": true,
             "exchangeTo": true,
             "exchangeFrom": true,
-            "syncToPit": true
+            "syncToPit": true,
+            "syncToExchange": true
           },
           "coinCode": "BCH",
           "coinTicker": "BCH",
@@ -95,7 +97,8 @@
             "lockbox": false,
             "exchangeTo": false,
             "exchangeFrom": true,
-            "syncToPit": false
+            "syncToPit": false,
+            "syncToExchange": false
           },
           "coinCode": "BSV",
           "coinTicker": "BSV",
@@ -116,7 +119,8 @@
             "lockbox": true,
             "exchangeTo": true,
             "exchangeFrom": true,
-            "syncToPit": true
+            "syncToPit": true,
+            "syncToExchange": true
           },
           "coinCode": "ETH",
           "coinTicker": "ETH",
@@ -143,7 +147,8 @@
             "lockbox": false,
             "exchangeTo": true,
             "exchangeFrom": true,
-            "syncToPit": true
+            "syncToPit": true,
+            "syncToExchange": true
           },
           "coinCode": "PAX",
           "coinTicker": "PAX",
@@ -167,7 +172,8 @@
             "lockbox": false,
             "exchangeTo": false,
             "exchangeFrom": false,
-            "syncToPit": false
+            "syncToPit": false,
+            "syncToExchange": false
           },
           "campaign": "BLOCKSTACK",
           "coinCode": "STX",
@@ -189,7 +195,8 @@
             "lockbox": true,
             "exchangeTo": true,
             "exchangeFrom": true,
-            "syncToPit": true
+            "syncToPit": true,
+            "syncToExchange": true
           },
           "campaign": "sunriver",
           "coinCode": "XLM",
@@ -312,9 +319,6 @@
           "iSignThisDomain": "https://stage-verify.isignthis.com"
         }
       },
-      "thePit": {
-        "countries": []
-      },
       "sfox": {
         "countries": [
           "US"
@@ -379,6 +383,7 @@
     "coinifyPaymentDomain": "https://pay.sandbox.coinify.com",
     "comRoot": "https://staging.blockchain.com",
     "comWalletApp": "https://wallet-frontend-v4.staging.blockchain.info",
+    "exchange": "https://pit.staging.blockchain.info",
     "horizon": "https://horizon.blockchain.info",
     "ledger": "https://manager.api.live.ledger.com",
     "ledgerSocket": "wss://api.ledgerwallet.com",

--- a/testnet/wallet-options-v4.json
+++ b/testnet/wallet-options-v4.json
@@ -60,7 +60,8 @@
             "lockbox": true,
             "exchangeTo": true,
             "exchangeFrom": true,
-            "syncToPit": true
+            "syncToPit": true,
+            "syncToExchange": true
           },
           "coinCode": "BTC",
           "coinTicker": "BTC",
@@ -87,7 +88,8 @@
             "lockbox": true,
             "exchangeTo": true,
             "exchangeFrom": true,
-            "syncToPit": true
+            "syncToPit": true,
+            "syncToExchange": true
           },
           "coinCode": "BCH",
           "coinTicker": "BCH",
@@ -111,7 +113,8 @@
             "lockbox": false,
             "exchangeTo": false,
             "exchangeFrom": true,
-            "syncToPit": false
+            "syncToPit": false,
+            "syncToExchange": true
           },
           "coinCode": "BSV",
           "coinTicker": "BSV",
@@ -132,7 +135,8 @@
             "lockbox": true,
             "exchangeTo": true,
             "exchangeFrom": true,
-            "syncToPit": true
+            "syncToPit": true,
+            "syncToExchange": true
           },
           "coinCode": "ETH",
           "coinTicker": "ETH",
@@ -159,7 +163,8 @@
             "lockbox": false,
             "exchangeTo": true,
             "exchangeFrom": true,
-            "syncToPit": true
+            "syncToPit": true,
+            "syncToExchange": true
           },
           "coinCode": "PAX",
           "coinTicker": "PAX",
@@ -183,7 +188,8 @@
             "lockbox": false,
             "exchangeTo": false,
             "exchangeFrom": false,
-            "syncToPit": false
+            "syncToPit": false,
+            "syncToExchange": false
           },
           "campaign": "BLOCKSTACK",
           "coinCode": "STX",
@@ -205,7 +211,8 @@
             "lockbox": true,
             "exchangeTo": true,
             "exchangeFrom": true,
-            "syncToPit": true
+            "syncToPit": true,
+            "syncToExchange": true
           },
           "campaign": "sunriver",
           "coinCode": "XLM",
@@ -327,9 +334,6 @@
           "iSignThisDomain": "https://stage-verify.isignthis.com"
         }
       },
-      "thePit": {
-        "countries": []
-      },
       "sfox": {
         "countries": [
           "US"
@@ -394,6 +398,7 @@
     "coinifyPaymentDomain": "https://pay.sandbox.coinify.com",
     "comRoot": "https://testnet.blockchain.com",
     "comWalletApp": "https://wallet-frontend-v4.testnet.blockchain.info",
+    "exchange": "https://exchange.dev.blockchain.info",
     "horizon": "https://horizon-testnet.stellar.org",
     "ledger": "https://manager.api.live.ledger.com",
     "ledgerSocket": "wss://api.ledgerwallet.com",


### PR DESCRIPTION
Leaving the old PIT urls and flags in temporarily for backwards compatibility and thus easier prod deploy.

Will create another PR in future to remove PIT references completely.