### PR TITLE
Wallet Options: Disabling maintenance flag on dev and staging.

### DIFF
--- a/dev/wallet-options.json
+++ b/dev/wallet-options.json
@@ -295,7 +295,7 @@
     }
   },
   "webHardFork": {},
-  "maintenance": true,
+  "maintenance": false,
   "mobileInfo": {
     "en": "We are experiencing an outage with the wallet. Please rest assured your funds are safe."
   }

--- a/staging/wallet-options.json
+++ b/staging/wallet-options.json
@@ -303,7 +303,7 @@
     }
   },
   "webHardFork": {},
-  "maintenance": true,
+  "maintenance": false,
   "mobileInfo": {
     "en": "We are experiencing an outage with the wallet. Please rest assured your funds are safe."
   }


### PR DESCRIPTION
Given dev and staging environments aren't down, we want to disable maintenance flag on them so we can login.